### PR TITLE
add active class to navigator for custom styling

### DIFF
--- a/src/CatCarousel.vue
+++ b/src/CatCarousel.vue
@@ -60,7 +60,8 @@
       <div
         v-for="index in maxSlide"
         :key="index"
-        :class="['cat-carousel__indicators__item']"
+        class="cat-carousel__indicators__item"
+        :class="{ 'active': (track + 1) === index }"
         :style="[indicatorsItemSizeStyle, selectedIndicator(index) && activeIndicatorStyle]"
       />
     </div>


### PR DESCRIPTION
This PR add a class called active to navigator element so that other dev could customized the indicator styling